### PR TITLE
test: PasswordEncoder.matches() 동작 검증을 위한 테스트 케이스 추가

### DIFF
--- a/src/test/java/org/example/expert/config/PasswordEncoderTest.java
+++ b/src/test/java/org/example/expert/config/PasswordEncoderTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(SpringExtension.class)
@@ -19,10 +20,14 @@ class PasswordEncoderTest {
         String rawPassword = "testPassword";
         String encodedPassword = passwordEncoder.encode(rawPassword);
 
-        // when
-        boolean matches = passwordEncoder.matches(encodedPassword, rawPassword);
+        // when(matches 메서드의 첫번째 파라미터는 평문이고, 두번쨰 파라미터는 변환된 코드이다.
+        boolean matches = passwordEncoder.matches(rawPassword, encodedPassword);
+        boolean notMatches = passwordEncoder.matches(encodedPassword, rawPassword);
+        boolean notMatches2 = passwordEncoder.matches("wrongPassword", encodedPassword);
 
         // then
         assertTrue(matches);
+        assertFalse(notMatches);
+        assertFalse(notMatches2);
     }
 }


### PR DESCRIPTION
PasswordEncoder의 matches 메서드가 예상대로 작동하는지 검증하는 3가지 테스트 케이스 추가. 각 테스트 케이스는 다양한 입력 조건에서 메서드의 정확성을 확인하였으며, 모든 케이스 통과 확인.